### PR TITLE
rename basque language 'eus' to 'eu'

### DIFF
--- a/pyjokes/jokes_eu.py
+++ b/pyjokes/jokes_eu.py
@@ -12,7 +12,7 @@ adult = [
     '',
 ]
 
-jokes_eus = {
+jokes_eu = {
     'neutral': neutral,
     'adult': adult,
     'all': neutral + adult,

--- a/pyjokes/pyjokes.py
+++ b/pyjokes/pyjokes.py
@@ -5,14 +5,14 @@ from .jokes_en import jokes_en
 from .jokes_de import jokes_de
 from .jokes_es import jokes_es
 from .jokes_gl import jokes_gl
-from .jokes_eus import jokes_eus
+from .jokes_eu import jokes_eu
 
 all_jokes = {
     'en': jokes_en,
     'de': jokes_de,
     'es': jokes_es,
     'gl': jokes_gl,
-    'eus' : jokes_eus,
+    'eu': jokes_eu,
 }
 
 
@@ -31,7 +31,7 @@ def get_jokes(language='en', category='neutral'):
     category: str
         Choices: 'neutral', 'adult', 'chuck', 'all'
     lang: str
-        Choices: 'en', 'de', 'es', 'gl', 'eus'
+        Choices: 'en', 'de', 'es', 'gl', 'eu'
 
     Returns
     -------
@@ -56,7 +56,7 @@ def get_joke(language='en', category='neutral'):
     category: str
         Choices: 'neutral', 'adult', 'chuck', 'all'
     lang: str
-        Choices: 'en', 'de', 'es', 'gl', 'eus'
+        Choices: 'en', 'de', 'es', 'gl', 'eu'
 
     Returns
     -------

--- a/scripts/pyjoke
+++ b/scripts/pyjoke
@@ -21,7 +21,7 @@ def create_argparser():
     parser.add_argument(
         '-l', '--language',
         dest='language',
-        choices=['en', 'de', 'es', 'gl', 'eus'],
+        choices=['en', 'de', 'es', 'gl', 'eu'],
         default='en',
         help='Joke language.'
     )

--- a/tests/test_get_joke.py
+++ b/tests/test_get_joke.py
@@ -3,7 +3,7 @@ from pyjokes import get_joke, get_jokes
 from pyjokes.pyjokes import LanguageNotFoundError, CategoryNotFoundError
 
 
-languages = ['en', 'de', 'es', 'gl']
+languages = ['en', 'de', 'es', 'gl', 'eu']
 categories = ['neutral', 'adult', 'all']
 test_data = ['', 'abc', '123']
 

--- a/tests/test_joke_encoding.py
+++ b/tests/test_joke_encoding.py
@@ -2,6 +2,7 @@ from pyjokes.jokes_en import jokes_en
 from pyjokes.jokes_de import jokes_de
 from pyjokes.jokes_es import jokes_es
 from pyjokes.jokes_gl import jokes_gl
+from pyjokes.jokes_eu import jokes_eu
 
 
 #test if joke is windows compatible
@@ -15,7 +16,7 @@ def _test_default_locale(joke):
 
 #unix is full compatible - no need of tests
 def test_jokes_lengths():
-    jokes_sets = [jokes_en, jokes_es, jokes_de, jokes_gl]
+    jokes_sets = [jokes_en, jokes_es, jokes_de, jokes_gl, jokes_eu]
     for jokes in jokes_sets:
         for j in jokes['all']:
             _test_default_locale(j)

--- a/tests/test_joke_length.py
+++ b/tests/test_joke_length.py
@@ -2,6 +2,7 @@ from pyjokes.jokes_en import jokes_en
 from pyjokes.jokes_de import jokes_de
 from pyjokes.jokes_es import jokes_es
 from pyjokes.jokes_gl import jokes_gl
+from pyjokes.jokes_eu import jokes_eu
 
 
 def _test_joke_length(joke):
@@ -14,6 +15,6 @@ def _test_joke_group(jokes):
 
 
 def test_jokes_lengths():
-    jokes_sets = [jokes_en, jokes_es, jokes_de, jokes_gl]
+    jokes_sets = [jokes_en, jokes_es, jokes_de, jokes_gl, jokes_eu]
     for jokes in jokes_sets:
         _test_joke_group(jokes['all'])


### PR DESCRIPTION
Basque language code is 'eu', so the code used here should be that too.