### PR TITLE
Include license file in sdist archive on pypi

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include README.rst
+include LICENCE.txt


### PR DESCRIPTION
As licenses require copy to be distributed together with the sourcecode.