### PR TITLE
Update README, twister option does not exist

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,6 @@ Use the `-c` flag to get jokes from a specific category. Options::
     -c neutral [default] (neutral geek jokes)
     -c chuck (Chuck Norris geek jokes)
     -c all (all jokes)
-    -c twister (Tongue-twister)
 
 You can also access the jokes in your own project by importing `pyjokes` and
 using the functions `get_joke` and `get_jokes`.


### PR DESCRIPTION
The `-c twister` option does not exist, but is mentioned in the readme as an example. 
This can be confusing.